### PR TITLE
Usage of CRAM, optimisation of BAM sort/indexing and run checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
-[*.{md,yml,yaml,html,css,scss,js}]
+[*.{md,yml,yaml,html,css,scss,js,cff}]
 indent_size = 2
 
 # These files are edited and tested upstream in nf-core/modules

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/hgts
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)
-  - [ ] If necessary, also make a PR on the nf-core/hgtseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
+- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/hgtseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
 - [ ] Make sure your code lints (`nf-core lint`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.

--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -25,6 +25,3 @@ jobs:
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/hgtseq/results-${{ github.sha }}"
             }
           profiles: test_full,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -23,6 +23,3 @@ jobs:
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/hgtseq/results-test-${{ github.sha }}"
             }
           profiles: test,aws_tower
-          nextflow_config: |
-            process.errorStrategy = 'retry'
-            process.maxRetries = 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   NXF_ANSI_LOG: false
-  CAPSULE_LOG: none
 
 jobs:
   test:
@@ -20,27 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Nextflow versions
-        include:
-          # Test pipeline minimum Nextflow version
-          - NXF_VER: "21.10.3"
-            NXF_EDGE: ""
-          # Test latest edge release of Nextflow
-          - NXF_VER: ""
-            NXF_EDGE: "1"
+        NXF_VER:
+          - "21.10.3"
+          - "latest-everything"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
       - name: Install Nextflow
-        env:
-          NXF_VER: ${{ matrix.NXF_VER }}
-          # Uncomment only if the edge release is more recent than the latest stable release
-          # See https://github.com/nextflow-io/nextflow/issues/2467
-          # NXF_EDGE: ${{ matrix.NXF_EDGE }}
-        run: |
-          wget -qO- get.nextflow.io | bash
-          sudo mv nextflow /usr/local/bin/
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
 
       - name: Test with FASTQ
         run: |
@@ -49,5 +38,3 @@ jobs:
       - name: Test with BAM
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_bam,docker --outdir ./results
-
-#

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -1,0 +1,55 @@
+name: Fix linting from a comment
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+    if: >
+      contains(github.event.comment.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@nf-core-bot fix linting') &&
+      github.repository == 'nf-core/hgtseq'
+    runs-on: ubuntu-latest
+    steps:
+      # Use the @nf-core-bot token to check out so we can push later
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.nf_core_bot_auth_token }}
+
+      # Action runs on the issue comment, so we don't get the PR by default
+      # Use the gh cli to check out the PR
+      - name: Checkout Pull Request
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+
+      - uses: actions/setup-node@v2
+
+      - name: Install Prettier
+        run: npm install -g prettier @prettier/plugin-php
+
+      # Check that we actually need to fix something
+      - name: Run 'prettier --check'
+        id: prettier_status
+        run: |
+          if prettier --check ${GITHUB_WORKSPACE}; then
+            echo "::set-output name=result::pass"
+          else
+            echo "::set-output name=result::fail"
+          fi
+
+      - name: Run 'prettier --write'
+        if: steps.prettier_status.outputs.result == 'fail'
+        run: prettier --write ${GITHUB_WORKSPACE}
+
+      - name: Commit & push changes
+        if: steps.prettier_status.outputs.result == 'fail'
+        run: |
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git add .
+          git status
+          git commit -m "[automated] Fix linting with Prettier"
+          git push

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -35,6 +35,36 @@ jobs:
       - name: Run Prettier --check
         run: prettier --check ${GITHUB_WORKSPACE}
 
+  PythonBlack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check code lints with Black
+        uses: psf/black@stable
+
+      # If the above check failed, post a comment on the PR explaining the failure
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            ## Python linting (`black`) is failing
+
+            To keep the code consistent with lots of contributors, we run automated code consistency checks.
+            To fix this CI test, please run:
+
+            * Install [`black`](https://black.readthedocs.io/en/stable/): `pip install black`
+            * Fix formatting errors in your pipeline: `black .`
+
+            Once you push these changes the test should pass, and you can hide this comment :+1:
+
+            We highly recommend setting up Black in your code editor so that this formatting is done automatically on save. Ask about it on Slack for help!
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false
+
   nf-core:
     runs-on: ubuntu-latest
     steps:
@@ -42,15 +72,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Nextflow
-        env:
-          CAPSULE_LOG: none
-        run: |
-          wget -qO- get.nextflow.io | bash
-          sudo mv nextflow /usr/local/bin/
+        uses: nf-core/setup-nextflow@v1
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.7"
           architecture: "x64"
 
       - name: Install dependencies

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,9 @@
 email_template.html
+.nextflow*
+work/
+data/
+results/
+.DS_Store
+testing/
+testing*
+*.pyc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: "If you use `nf-core tools` in your work, please cite the `nf-core` publication"
+authors:
+  - family-names: Ewels
+    given-names: Philip
+  - family-names: Peltzer
+    given-names: Alexander
+  - family-names: Fillinger
+    given-names: Sven
+  - family-names: Patel
+    given-names: Harshil
+  - family-names: Alneberg
+    given-names: Johannes
+  - family-names: Wilm
+    given-names: Andreas
+  - family-names: Ulysse Garcia
+    given-names: Maxime
+  - family-names: Di Tommaso
+    given-names: Paolo
+  - family-names: Nahnsen
+    given-names: Sven
+title: "The nf-core framework for community-curated bioinformatics pipelines."
+version: 2.4.1
+doi: 10.1038/s41587-020-0439-x
+date-released: 2022-05-16
+url: https://github.com/nf-core/tools
+prefered-citation:
+  type: article
+  authors:
+    - family-names: Ewels
+      given-names: Philip
+    - family-names: Peltzer
+      given-names: Alexander
+    - family-names: Fillinger
+      given-names: Sven
+    - family-names: Patel
+      given-names: Harshil
+    - family-names: Alneberg
+      given-names: Johannes
+    - family-names: Wilm
+      given-names: Andreas
+    - family-names: Ulysse Garcia
+      given-names: Maxime
+    - family-names: Di Tommaso
+      given-names: Paolo
+    - family-names: Nahnsen
+      given-names: Sven
+  doi: 10.1038/s41587-020-0439-x
+  journal: nature biotechnology
+  start: 276
+  end: 278
+  title: "The nf-core framework for community-curated bioinformatics pipelines."
+  issue: 3
+  volume: 38
+  year: 2020
+  url: https://dx.doi.org/10.1038/s41587-020-0439-x

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 
 On release, automated continuous integration tests run the pipeline on a full-sized dataset on the AWS cloud infrastructure. This ensures that the pipeline runs on AWS, has sensible resource allocation defaults set to run on real-world datasets, and permits the persistent storage of results to benchmark between pipeline releases and other analysis sources. The results obtained from the full-sized test can be viewed on the [nf-core website](https://nf-co.re/hgtseq/results).
 
-
 ## Functionality Overview
 
 A graphical view of the pipeline can be seen below.
@@ -74,7 +73,7 @@ Note that some form of configuration will be needed so that Nextflow knows how t
    --genome GRCh38 \
    -profile <docker/singularity/podman/shifter/charliecloud/conda/institute> \
    --krakendb /path/to/kraken_db \
-  --kronadb /path/to/krona_db/taxonomy.tab
+   --kronadb /path/to/krona_db/taxonomy.tab
    ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -46,22 +46,16 @@ A graphical view of the pipeline can be seen below.
 
 3. Download the pipeline and test it on a minimal dataset with a single command:
 
-<<<<<<< HEAD
 - FASTQ input:
-=======
-   ```bash
-   nextflow run nf-core/hgtseq -profile test,YOURPROFILE --outdir <OUTDIR>
-   ```
->>>>>>> TEMPLATE
 
 ```console
-nextflow run nf-core/hgtseq -profile test,YOURPROFILE --outdir <OUTDIR>
+   nextflow run nf-core/hgtseq -profile test,YOURPROFILE --outdir <OUTDIR>
 ```
 
 - BAM input:
 
 ```console
-nextflow run nf-core/hgtseq -profile test_bam,YOURPROFILE --outdir <OUTDIR>
+   nextflow run nf-core/hgtseq -profile test_bam,YOURPROFILE --outdir <OUTDIR>
 ```
 
 Note that some form of configuration will be needed so that Nextflow knows how to fetch the required software. This is usually done in the form of a config profile (`YOURPROFILE` in the example command above). You can chain multiple config profiles in a comma-separated string.
@@ -73,15 +67,14 @@ Note that some form of configuration will be needed so that Nextflow knows how t
 
 4. Start running your own analysis!
 
-<<<<<<< HEAD
    ```console
-   nextflow run nf-core/hgtseq --input <YOURINPUT>.csv --outdir <OUTDIR> --genome GRCh38 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
-=======
-   <!-- TODO nf-core: Update the example "typical command" below used to run the pipeline -->
-
-   ```bash
-   nextflow run nf-core/hgtseq --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
->>>>>>> TEMPLATE
+   nextflow run nf-core/hgtseq \
+   --input <YOURINPUT>.csv \
+   --outdir <OUTDIR> \
+   --genome GRCh38 \
+   -profile <docker/singularity/podman/shifter/charliecloud/conda/institute> \
+   --krakendb /path/to/kraken_db \
+  --kronadb /path/to/krona_db/taxonomy.tab
    ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 # ![nf-core/hgtseq](docs/images/nf-core-hgtseq_logo_light.png#gh-light-mode-only) ![nf-core/hgtseq](docs/images/nf-core-hgtseq_logo_dark.png#gh-dark-mode-only)
 
-[![GitHub Actions CI Status](https://github.com/nf-core/hgtseq/workflows/nf-core%20CI/badge.svg)](https://github.com/nf-core/hgtseq/actions?query=workflow%3A%22nf-core+CI%22)
-[![GitHub Actions Linting Status](https://github.com/nf-core/hgtseq/workflows/nf-core%20linting/badge.svg)](https://github.com/nf-core/hgtseq/actions?query=workflow%3A%22nf-core+linting%22)
-[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/hgtseq/results)
-[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
+[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/hgtseq/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.10.3-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.10.3-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)
+[![Launch on Nextflow Tower](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Nextflow%20Tower-%234256e7)](https://tower.nf/launch?pipeline=https://github.com/nf-core/hgtseq)
 
-[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23hgtseq-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/hgtseq)
-[![Follow on Twitter](http://img.shields.io/badge/twitter-%40nf__core-1DA1F2?labelColor=000000&logo=twitter)](https://twitter.com/nf_core)
-[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)
+[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23hgtseq-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/hgtseq)[![Follow on Twitter](http://img.shields.io/badge/twitter-%40nf__core-1DA1F2?labelColor=000000&logo=twitter)](https://twitter.com/nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)
 
 ## Introduction
 
@@ -21,6 +17,7 @@
 The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. Where possible, these processes have been submitted to and installed from [nf-core/modules](https://github.com/nf-core/modules) in order to make them available to all nf-core pipelines, and to everyone within the Nextflow community!
 
 On release, automated continuous integration tests run the pipeline on a full-sized dataset on the AWS cloud infrastructure. This ensures that the pipeline runs on AWS, has sensible resource allocation defaults set to run on real-world datasets, and permits the persistent storage of results to benchmark between pipeline releases and other analysis sources. The results obtained from the full-sized test can be viewed on the [nf-core website](https://nf-co.re/hgtseq/results).
+
 
 ## Functionality Overview
 
@@ -49,7 +46,13 @@ A graphical view of the pipeline can be seen below.
 
 3. Download the pipeline and test it on a minimal dataset with a single command:
 
+<<<<<<< HEAD
 - FASTQ input:
+=======
+   ```bash
+   nextflow run nf-core/hgtseq -profile test,YOURPROFILE --outdir <OUTDIR>
+   ```
+>>>>>>> TEMPLATE
 
 ```console
 nextflow run nf-core/hgtseq -profile test,YOURPROFILE --outdir <OUTDIR>
@@ -70,8 +73,15 @@ Note that some form of configuration will be needed so that Nextflow knows how t
 
 4. Start running your own analysis!
 
+<<<<<<< HEAD
    ```console
    nextflow run nf-core/hgtseq --input <YOURINPUT>.csv --outdir <OUTDIR> --genome GRCh38 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
+=======
+   <!-- TODO nf-core: Update the example "typical command" below used to run the pipeline -->
+
+   ```bash
+   nextflow run nf-core/hgtseq --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile <docker/singularity/podman/shifter/charliecloud/conda/institute>
+>>>>>>> TEMPLATE
    ```
 
 ## Documentation

--- a/assets/analysis_report.Rmd
+++ b/assets/analysis_report.Rmd
@@ -65,7 +65,7 @@ for (sample in sampleids){
 
 joint_data = data_integrations %>%
   left_join(data_classified, by = "read_name")
-head(joint_data)
+    head(joint_data)
 ```
 
 # Filter data by non-Human classification

--- a/assets/analysis_report.Rmd
+++ b/assets/analysis_report.Rmd
@@ -27,6 +27,9 @@ library(tidyverse)
 library(stringr)
 
 sampleids <- unlist(strsplit(params$sampleids, ","))
+## for safety we remove new line characters in case the number of samples
+## exceeds the lenght of a line in the terminal in use
+sampleids = str_replace_all(sampleids, "[\r\n]" , "")
 
 data_classified = tibble()
 data_integrations = tibble()
@@ -53,6 +56,7 @@ for (sample in sampleids){
       sample = sample
     )
   )
+  rm(est,sample)
 }
 ```
 # join delle due tibble

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -6,7 +6,6 @@
                                         `._,._,'
   nf-core/hgtseq v${version}
 ----------------------------------------------------
-
 Run Name: $runName
 
 <% if (success){

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+
+
+"""Provide a command line tool to validate and transform tabular samplesheets."""
+
+
+import argparse
+import csv
+import logging
+import sys
+from collections import Counter
+from pathlib import Path
+
+logger = logging.getLogger()
+
+
+class RowChecker:
+    """
+    Define a service that can validate and transform each given row.
+
+    Attributes:
+        modified (list): A list of dicts, where each dict corresponds to a previously
+            validated and transformed row. The order of rows is maintained.
+
+    """
+
+    VALID_FORMATS = (
+        ".fq.gz",
+        ".fastq.gz",
+    )
+
+    def __init__(
+        self,
+        sample_col="sample",
+        first_col="fastq_1",
+        second_col="fastq_2",
+        single_col="single_end",
+        **kwargs,
+    ):
+        """
+        Initialize the row checker with the expected column names.
+
+        Args:
+            sample_col (str): The name of the column that contains the sample name
+                (default "sample").
+            first_col (str): The name of the column that contains the first (or only)
+                FASTQ file path (default "fastq_1").
+            second_col (str): The name of the column that contains the second (if any)
+                FASTQ file path (default "fastq_2").
+            single_col (str): The name of the new column that will be inserted and
+                records whether the sample contains single- or paired-end sequencing
+                reads (default "single_end").
+
+        """
+        super().__init__(**kwargs)
+        self._sample_col = sample_col
+        self._first_col = first_col
+        self._second_col = second_col
+        self._single_col = single_col
+        self._seen = set()
+        self.modified = []
+
+    def validate_and_transform(self, row):
+        """
+        Perform all validations on the given row and insert the read pairing status.
+
+        Args:
+            row (dict): A mapping from column headers (keys) to elements of that row
+                (values).
+
+        """
+        self._validate_sample(row)
+        self._validate_first(row)
+        self._validate_second(row)
+        self._validate_pair(row)
+        self._seen.add((row[self._sample_col], row[self._first_col]))
+        self.modified.append(row)
+
+    def _validate_sample(self, row):
+        """Assert that the sample name exists and convert spaces to underscores."""
+        if len(row[self._sample_col]) <= 0:
+            raise AssertionError("Sample input is required.")
+        # Sanitize samples slightly.
+        row[self._sample_col] = row[self._sample_col].replace(" ", "_")
+
+    def _validate_first(self, row):
+        """Assert that the first FASTQ entry is non-empty and has the right format."""
+        if len(row[self._first_col]) <= 0:
+            raise AssertionError("At least the first FASTQ file is required.")
+        self._validate_fastq_format(row[self._first_col])
+
+    def _validate_second(self, row):
+        """Assert that the second FASTQ entry has the right format if it exists."""
+        if len(row[self._second_col]) > 0:
+            self._validate_fastq_format(row[self._second_col])
+
+    def _validate_pair(self, row):
+        """Assert that read pairs have the same file extension. Report pair status."""
+        if row[self._first_col] and row[self._second_col]:
+            row[self._single_col] = False
+            first_col_suffix = Path(row[self._first_col]).suffixes[-2:]
+            second_col_suffix = Path(row[self._second_col]).suffixes[-2:]
+            if first_col_suffix != second_col_suffix:
+                raise AssertionError("FASTQ pairs must have the same file extensions.")
+        else:
+            row[self._single_col] = True
+
+    def _validate_fastq_format(self, filename):
+        """Assert that a given filename has one of the expected FASTQ extensions."""
+        if not any(filename.endswith(extension) for extension in self.VALID_FORMATS):
+            raise AssertionError(
+                f"The FASTQ file has an unrecognized extension: {filename}\n"
+                f"It should be one of: {', '.join(self.VALID_FORMATS)}"
+            )
+
+    def validate_unique_samples(self):
+        """
+        Assert that the combination of sample name and FASTQ filename is unique.
+
+        In addition to the validation, also rename all samples to have a suffix of _T{n}, where n is the
+        number of times the same sample exist, but with different FASTQ files, e.g., multiple runs per experiment.
+
+        """
+        if len(self._seen) != len(self.modified):
+            raise AssertionError("The pair of sample name and FASTQ must be unique.")
+        seen = Counter()
+        for row in self.modified:
+            sample = row[self._sample_col]
+            seen[sample] += 1
+            row[self._sample_col] = f"{sample}_T{seen[sample]}"
+
+
+def read_head(handle, num_lines=10):
+    """Read the specified number of lines from the current position in the file."""
+    lines = []
+    for idx, line in enumerate(handle):
+        if idx == num_lines:
+            break
+        lines.append(line)
+    return "".join(lines)
+
+
+def sniff_format(handle):
+    """
+    Detect the tabular format.
+
+    Args:
+        handle (text file): A handle to a `text file`_ object. The read position is
+        expected to be at the beginning (index 0).
+
+    Returns:
+        csv.Dialect: The detected tabular format.
+
+    .. _text file:
+        https://docs.python.org/3/glossary.html#term-text-file
+
+    """
+    peek = read_head(handle)
+    handle.seek(0)
+    sniffer = csv.Sniffer()
+    if not sniffer.has_header(peek):
+        logger.critical("The given sample sheet does not appear to contain a header.")
+        sys.exit(1)
+    dialect = sniffer.sniff(peek)
+    return dialect
+
+
+def check_samplesheet(file_in, file_out):
+    """
+    Check that the tabular samplesheet has the structure expected by nf-core pipelines.
+
+    Validate the general shape of the table, expected columns, and each row. Also add
+    an additional column which records whether one or two FASTQ reads were found.
+
+    Args:
+        file_in (pathlib.Path): The given tabular samplesheet. The format can be either
+            CSV, TSV, or any other format automatically recognized by ``csv.Sniffer``.
+        file_out (pathlib.Path): Where the validated and transformed samplesheet should
+            be created; always in CSV format.
+
+    Example:
+        This function checks that the samplesheet follows the following structure,
+        see also the `viral recon samplesheet`_::
+
+            sample,fastq_1,fastq_2
+            SAMPLE_PE,SAMPLE_PE_RUN1_1.fastq.gz,SAMPLE_PE_RUN1_2.fastq.gz
+            SAMPLE_PE,SAMPLE_PE_RUN2_1.fastq.gz,SAMPLE_PE_RUN2_2.fastq.gz
+            SAMPLE_SE,SAMPLE_SE_RUN1_1.fastq.gz,
+
+    .. _viral recon samplesheet:
+        https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv
+
+    """
+    required_columns = {"sample", "fastq_1", "fastq_2"}
+    # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
+    with file_in.open(newline="") as in_handle:
+        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        # Validate the existence of the expected header columns.
+        if not required_columns.issubset(reader.fieldnames):
+            req_cols = ", ".join(required_columns)
+            logger.critical(f"The sample sheet **must** contain these column headers: {req_cols}.")
+            sys.exit(1)
+        # Validate each row.
+        checker = RowChecker()
+        for i, row in enumerate(reader):
+            try:
+                checker.validate_and_transform(row)
+            except AssertionError as error:
+                logger.critical(f"{str(error)} On line {i + 2}.")
+                sys.exit(1)
+        checker.validate_unique_samples()
+    header = list(reader.fieldnames)
+    header.insert(1, "single_end")
+    # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
+    with file_out.open(mode="w", newline="") as out_handle:
+        writer = csv.DictWriter(out_handle, header, delimiter=",")
+        writer.writeheader()
+        for row in checker.modified:
+            writer.writerow(row)
+
+
+def parse_args(argv=None):
+    """Define and immediately parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate and transform a tabular samplesheet.",
+        epilog="Example: python check_samplesheet.py samplesheet.csv samplesheet.valid.csv",
+    )
+    parser.add_argument(
+        "file_in",
+        metavar="FILE_IN",
+        type=Path,
+        help="Tabular input samplesheet in CSV or TSV format.",
+    )
+    parser.add_argument(
+        "file_out",
+        metavar="FILE_OUT",
+        type=Path,
+        help="Transformed output samplesheet in CSV format.",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-level",
+        help="The desired log level (default WARNING).",
+        choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        default="WARNING",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Coordinate argument parsing and program execution."""
+    args = parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="[%(levelname)s] %(message)s")
+    if not args.file_in.is_file():
+        logger.error(f"The given input file {args.file_in} was not found!")
+        sys.exit(2)
+    args.file_out.parent.mkdir(parents=True, exist_ok=True)
+    check_samplesheet(args.file_in, args.file_out)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/base.config
+++ b/conf/base.config
@@ -19,6 +19,12 @@ process {
     maxErrors     = '-1'
 
     // Process-specific resource requirements
+
+    withLabel:process_single {
+        cpus   = { check_max( 1                  , 'cpus'    ) }
+        memory = { check_max( 6.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 4.h  * task.attempt, 'time'    ) }
+    }
     withLabel:process_low {
         cpus   = { check_max( 2     * task.attempt, 'cpus'    ) }
         memory = { check_max( 6.GB * task.attempt, 'memory'  ) }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -100,6 +100,7 @@ process {
             path: { "${params.outdir}/preprocess/converted_reads/single_unmapped" },
             mode: params.publish_dir_mode
         ]
+        ext.args = '-n'
     }
 
     withName: SAMTOOLS_FASTQ_BOTH {
@@ -107,6 +108,7 @@ process {
             path: { "${params.outdir}/preprocess/converted_reads/both_unmapped" },
             mode: params.publish_dir_mode
         ]
+        ext.args = '-n'
     }
 
     withName: PARSEOUTPUTS {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,16 +16,11 @@ The pipeline will auto-detect whether a sample is single- or paired-end using th
 
 The FASTQ file extension can be either _fastq.gz_ or _fastq_.
 
-<<<<<<< HEAD
 ```console
 sample,input1,input2
 testsample01,/path/to/file1_1.fastq.gz/path/to/file1_2.fastq.gz
 testsample02,/path/to/file2_1.fastq.gz,/path/to/file2_2.fastq.gz
 testsample03,/path/to/file3_1.fastq,/path/to/file3_2.fastq.gz
-=======
-```bash
---input '[path to samplesheet file]'
->>>>>>> TEMPLATE
 ```
 
 | Column   | Description                                                                                                                                                                            |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,11 +16,16 @@ The pipeline will auto-detect whether a sample is single- or paired-end using th
 
 The FASTQ file extension can be either _fastq.gz_ or _fastq_.
 
+<<<<<<< HEAD
 ```console
 sample,input1,input2
 testsample01,/path/to/file1_1.fastq.gz/path/to/file1_2.fastq.gz
 testsample02,/path/to/file2_1.fastq.gz,/path/to/file2_2.fastq.gz
 testsample03,/path/to/file3_1.fastq,/path/to/file3_2.fastq.gz
+=======
+```bash
+--input '[path to samplesheet file]'
+>>>>>>> TEMPLATE
 ```
 
 | Column   | Description                                                                                                                                                                            |
@@ -52,16 +57,22 @@ An [example samplesheet](../assets/samplesheet_bam.csv) has been provided with t
 The typical command for running the pipeline is as follows:
 
 ```console
-nextflow run nf-core/hgtseq --input samplesheet.csv --outdir <OUTDIR> --genome GRCh38 -profile <singularity,docker,conda>
+nextflow run nf-core/hgtseq \
+--input samplesheet.csv \
+--outdir <OUTDIR> \
+--genome GRCh38 \
+-profile <singularity,docker,conda> \
+--krakendb /path/to/kraken_db \
+--kronadb /path/to/krona_db/taxonomy.tab
 ```
 
 This will launch the pipeline with the `singularity,docker or conda` configuration profile. See below for more information about profiles.
 
 Note that the pipeline will create the following files in your working directory:
 
-```console
+```bash
 work                # Directory containing the nextflow working files
-<OUTIDR>            # Finished results in specified location (defined with --outdir)
+<OUTDIR>            # Finished results in specified location (defined with --outdir)
 .nextflow_log       # Log file from Nextflow
 # Other nextflow hidden files, eg. history of pipeline runs and old logs.
 ```
@@ -70,7 +81,7 @@ work                # Directory containing the nextflow working files
 
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
 
-```console
+```bash
 nextflow pull nf-core/hgtseq
 ```
 
@@ -246,7 +257,7 @@ Some HPC setups also allow you to run nextflow within a cluster job submitted yo
 In some cases, the Nextflow Java virtual machines can start to request a large amount of memory.
 We recommend adding the following line to your environment to limit this (typically in `~/.bashrc` or `~./bash_profile`):
 
-```console
+```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```
 

--- a/lib/WorkflowHgtseq.groovy
+++ b/lib/WorkflowHgtseq.groovy
@@ -10,6 +10,7 @@ class WorkflowHgtseq {
     public static void initialise(params, log) {
         genomeExistsError(params, log)
 
+
         if (!params.fasta) {
             log.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
             System.exit(1)
@@ -41,9 +42,7 @@ class WorkflowHgtseq {
         yaml_file_text        += "data: |\n"
         yaml_file_text        += "${summary_section}"
         return yaml_file_text
-    }
-
-    //
+    }//
     // Exit pipeline if incorrect --genome key provided
     //
     private static void genomeExistsError(params, log) {

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -56,6 +56,7 @@ class WorkflowMain {
         }
 
         // Print parameter summary log to screen
+
         log.info paramsSummaryLog(workflow, params, log)
 
         // Check that a -profile or Nextflow config has been provided to run the pipeline
@@ -75,17 +76,15 @@ class WorkflowMain {
             System.exit(1)
         }
     }
-
     //
     // Get attribute from genome config file e.g. fasta
     //
-    public static String getGenomeAttribute(params, attribute) {
-        def val = ''
+    public static Object getGenomeAttribute(params, attribute) {
         if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
             if (params.genomes[ params.genome ].containsKey(attribute)) {
-                val = params.genomes[ params.genome ][ attribute ]
+                return params.genomes[ params.genome ][ attribute ]
             }
         }
-        return val
+        return null
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@
     nf-core/hgtseq
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Github : https://github.com/nf-core/hgtseq
-    Website: https://nf-co.re/hgtseq
+Website: https://nf-co.re/hgtseq
     Slack  : https://nfcore.slack.com/channels/hgtseq
 ----------------------------------------------------------------------------------------
 */

--- a/modules.json
+++ b/modules.json
@@ -3,65 +3,88 @@
     "homePage": "https://github.com/nf-core/hgtseq",
     "repos": {
         "nf-core/modules": {
-            "bwa/index": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
-            },
-            "bwa/mem": {
-                "git_sha": "4f5274c3de0c9521f5033893ff61057a74c45ba9"
-            },
-            "bwamem2/index": {
-                "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
-            },
-            "bwamem2/mem": {
-                "git_sha": "4f5274c3de0c9521f5033893ff61057a74c45ba9"
-            },
-            "custom/dumpsoftwareversions": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
-            },
-            "fastqc": {
-                "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
-            },
-            "kraken2/kraken2": {
-                "git_sha": "abe025677cdd805cc93032341ab19885473c1a07"
-            },
-            "krona/ktimporttaxonomy": {
-                "git_sha": "9083d3bb3dfeae8dc61d6a2e9e097468af5fafcd"
-            },
-            "krona/ktupdatetaxonomy": {
-                "git_sha": "204dfba2d8635d1a73255538441544a0c1501d4d"
-            },
-            "multiqc": {
-                "git_sha": "e5f8924fabf4c8380f55fb7aee89fd2c268161b1"
-            },
-            "qualimap/bamqc": {
-                "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
-            },
-            "samtools/fastq": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/flagstat": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/idxstats": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/index": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/sort": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/stats": {
-                "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
-            },
-            "samtools/view": {
-                "git_sha": "6b64f9cb6c3dd3577931cc3cd032d6fb730000ce"
-            },
-            "trimgalore": {
-                "git_sha": "85ec13ff1fc2196c5a507ea497de468101baabed"
-            },
-            "untar": {
-                "git_sha": "51be617b1ca9bff973655eb899d591ed6ab253b5"
+            "git_url": "https://github.com/nf-core/modules.git",
+            "modules": {
+                "bwa/index": {
+                    "branch": "master",
+                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                },
+                "bwa/mem": {
+                    "branch": "master",
+                    "git_sha": "4f5274c3de0c9521f5033893ff61057a74c45ba9"
+                },
+                "bwamem2/index": {
+                    "branch": "master",
+                    "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
+                },
+                "bwamem2/mem": {
+                    "branch": "master",
+                    "git_sha": "4f5274c3de0c9521f5033893ff61057a74c45ba9"
+                },
+                "custom/dumpsoftwareversions": {
+                    "branch": "master",
+                    "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                },
+                "fastqc": {
+                    "branch": "master",
+                    "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
+                },
+                "kraken2/kraken2": {
+                    "branch": "master",
+                    "git_sha": "abe025677cdd805cc93032341ab19885473c1a07"
+                },
+                "krona/ktimporttaxonomy": {
+                    "branch": "master",
+                    "git_sha": "9083d3bb3dfeae8dc61d6a2e9e097468af5fafcd"
+                },
+                "krona/ktupdatetaxonomy": {
+                    "branch": "master",
+                    "git_sha": "204dfba2d8635d1a73255538441544a0c1501d4d"
+                },
+                "multiqc": {
+                    "branch": "master",
+                    "git_sha": "e5f8924fabf4c8380f55fb7aee89fd2c268161b1"
+                },
+                "qualimap/bamqc": {
+                    "branch": "master",
+                    "git_sha": "49b18b1639f4f7104187058866a8fab33332bdfe"
+                },
+                "samtools/fastq": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/flagstat": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/idxstats": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/index": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/sort": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/stats": {
+                    "branch": "master",
+                    "git_sha": "897c33d5da084b61109500ee44c01da2d3e4e773"
+                },
+                "samtools/view": {
+                    "branch": "master",
+                    "git_sha": "6b64f9cb6c3dd3577931cc3cd032d6fb730000ce"
+                },
+                "trimgalore": {
+                    "branch": "master",
+                    "git_sha": "85ec13ff1fc2196c5a507ea497de468101baabed"
+                },
+                "untar": {
+                    "branch": "master",
+                    "git_sha": "51be617b1ca9bff973655eb899d591ed6ab253b5"
+                }
             }
         }
     }

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-import yaml
 import platform
 from textwrap import dedent
+
+import yaml
 
 
 def _make_versions_html(versions):
@@ -58,11 +59,12 @@ versions_by_module = {}
 for process, process_versions in versions_by_process.items():
     module = process.split(":")[-1]
     try:
-        assert versions_by_module[module] == process_versions, (
-            "We assume that software versions are the same between all modules. "
-            "If you see this error-message it means you discovered an edge-case "
-            "and should open an issue in nf-core/tools. "
-        )
+        if versions_by_module[module] != process_versions:
+            raise AssertionError(
+                "We assume that software versions are the same between all modules. "
+                "If you see this error-message it means you discovered an edge-case "
+                "and should open an issue in nf-core/tools. "
+            )
     except KeyError:
         versions_by_module[module] = process_versions
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,7 @@ params {
     kronadb                    = null
     isbam                      = false
 
+
     // References
     genome                     = null
     igenomes_base              = 's3://ngi-igenomes/igenomes'
@@ -51,6 +52,7 @@ params {
     schema_ignore_params       = 'genomes'
     enable_conda               = false
 
+
     // Config options
     custom_config_version      = 'master'
     custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
@@ -58,6 +60,7 @@ params {
     config_profile_contact     = null
     config_profile_url         = null
     config_profile_name        = null
+
 
     // Max resource options
     // Defaults only, expecting to be overwritten
@@ -86,10 +89,20 @@ try {
 // }
 
 
+
 profiles {
     debug { process.beforeScript = 'echo $HOSTNAME' }
     conda {
         params.enable_conda    = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    mamba {
+        params.enable_conda    = true
+        conda.useMamba         = true
         docker.enabled         = false
         singularity.enabled    = false
         podman.enabled         = false
@@ -135,16 +148,22 @@ profiles {
         podman.enabled         = false
         shifter.enabled        = false
     }
+    gitpod {
+        executor.name          = 'local'
+        executor.cpus          = 16
+        executor.memory        = 60.GB
+    }
+    test_full { includeConfig 'conf/test_full.config' }
     test      {
         includeConfig 'conf/test.config'
         params.multiqc_runkraken = false
     }
-    test_full { includeConfig 'conf/test_full.config' }
     test_bam  {
         includeConfig 'conf/test_bam.config'
         params.multiqc_runkraken = false
     }
 }
+
 
 // Load igenomes.config if required
 if (!params.igenomes_ignore) {
@@ -152,6 +171,7 @@ if (!params.igenomes_ignore) {
 } else {
     params.genomes = [:]
 }
+
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -115,12 +115,12 @@
                 "krakendb": {
                     "type": "string",
                     "default": "None",
-                    "description": "Either a local path or a URL to compressed kraken database file"
+                    "description": "Either a local path or a URL to compressed kraken database folder"
                 },
                 "kronadb": {
                     "type": "string",
                     "default": "None",
-                    "description": "Either a local path or a URL to compressed .tab krona taxonomy"
+                    "description": "Either a local path or a URL to compressed .tab krona taxonomy file"
                 },
                 "gff": {
                     "type": "string",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+# Config file for Python. Mostly used to configure linting of bin/check_samplesheet.py with Black.
+# Should be kept the same as nf-core/tools to avoid fighting with template synchronisation.
+[tool.black]
+line-length = 120
+target_version = ["py37", "py38", "py39", "py310"]
+
+[tool.isort]
+profile = "black"
+known_first_party = ["nf_core"]
+multi_line_output = 3

--- a/subworkflows/local/classify_unmapped/main.nf
+++ b/subworkflows/local/classify_unmapped/main.nf
@@ -12,27 +12,17 @@ include { PARSEOUTPUTS                                } from '../../../modules/l
 workflow CLASSIFY_UNMAPPED {
 
     take:
-    bam  // channel: [ val(meta), [ bam ] ]
+    bam_bai  // channel: [ val(meta), path(bam), path(bai) ]
     db   // channel: [ path(database) ]
 
     main:
 
     ch_versions = Channel.empty()
 
-    SAMTOOLS_SORT ( bam )
-    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions)
-
-    SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
-    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions)
-
-    // joining channels because SAMTOOLS_VIEW needs a tuple
-    // combining [ [meta], bam, bai ]
-    ch_indexed_bam = SAMTOOLS_SORT.out.bam.join(SAMTOOLS_INDEX.out.bai)
-
-    SAMTOOLS_VIEW_SINGLE ( ch_indexed_bam, [] )
+    SAMTOOLS_VIEW_SINGLE ( bam_bai, [] )
     ch_versions = ch_versions.mix(SAMTOOLS_VIEW_SINGLE.out.versions)
 
-    SAMTOOLS_VIEW_BOTH ( ch_indexed_bam, [] )
+    SAMTOOLS_VIEW_BOTH ( bam_bai, [] )
     ch_versions = ch_versions.mix(SAMTOOLS_VIEW_BOTH.out.versions)
 
     PARSEOUTPUTS ( SAMTOOLS_VIEW_SINGLE.out.bam )

--- a/subworkflows/local/sortbam/main.nf
+++ b/subworkflows/local/sortbam/main.nf
@@ -1,0 +1,40 @@
+// runs SAMPLE_QC from either reads or bam files
+// or both after alignment
+
+include { SAMTOOLS_SORT     } from '../../../modules/nf-core/modules/samtools/sort/main'
+include { SAMTOOLS_INDEX    } from '../../../modules/nf-core/modules/samtools/index/main'
+
+
+
+workflow SORTBAM {
+
+    take:
+    bam        // channel: [mandatory] [ val(meta), path(bam) ]
+
+    main:
+    ch_versions = Channel.empty()
+
+    // samtools stats block needs the bam file to be sorted
+    // and indexed
+
+    SAMTOOLS_SORT ( bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+
+    SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    // additionally, the modules require a single channel containing
+    // both the bam file and its index
+    // which is the reason for creating an additional channel that joins
+    // both of them:
+
+    SAMTOOLS_SORT.out.bam
+        .join(SAMTOOLS_INDEX.out.bai, by: [0], remainder: true)
+        .set { bam_bai }
+
+
+    emit:
+    bam_only = SAMTOOLS_SORT.out.bam  // channel: [ val(meta), path(bam) ]
+    bam_bai  = bam_bai                // channel: [ val(meta), path(bam), path(bai) ]
+    versions = ch_versions            // channel: [ versions.yml ]
+}

--- a/workflows/hgtseq.nf
+++ b/workflows/hgtseq.nf
@@ -261,11 +261,11 @@ def create_input_channel(LinkedHashMap row) {
             exit 1, "ERROR: Please check input samplesheet -> file indicated in input1 column does not exist!\n${row.input1}"
         }
         // check whether input1 is a fastq or bam
-        if (!hasExtension(file1, "fastq.gz") && !hasExtension(file1, "fastq") && !hasExtension(file1, "bam")){
-            exit 1, "ERROR: input file in input1 column must be either a fastq or a bam file!\n${row.input1}"
+        if (!hasExtension(file1, "fastq.gz") && !hasExtension(file1, "fastq") && !hasExtension(file1, "bam") && !hasExtension(file1, "cram")){
+            exit 1, "ERROR: input file in input1 column must be either a fastq or a bam/cram file!\n${row.input1}"
         }
     } else {
-        exit 1, "ERROR: Please check input samplesheet -> a column named input1 with either fastq or bam input is mandatory!\n"
+        exit 1, "ERROR: Please check input samplesheet -> a column named input1 with either fastq or bam/cram input is mandatory!\n"
     }
     // single or paired end is set based on presence or absence of input2 column
     if (row.input2){
@@ -274,8 +274,8 @@ def create_input_channel(LinkedHashMap row) {
         if (!file2.exists()) {
             exit 1, "ERROR: Please check input samplesheet -> file indicated in input2 column does not exist!\n${row.input2}"
         }
-        if (getExtensionFromStringPath(row.input1) == ".bam"){
-            exit 1, "ERROR: when providing BAM input in column input1, column input2 should not exist"
+        if (getExtensionFromStringPath(row.input1) == ".bam" | getExtensionFromStringPath(row.input1) == ".cram"){
+            exit 1, "ERROR: when providing BAM or CRAM input in column input1, column input2 should not exist"
         }
         if (!(getExtensionFromStringPath(row.input1) == getExtensionFromStringPath(row.input2))){
             exit 1, "ERROR: when providing paired end fastq files, both input should have the same extension\n${row.input1}\n${row.input2}"

--- a/workflows/hgtseq.nf
+++ b/workflows/hgtseq.nf
@@ -135,7 +135,7 @@ workflow HGTSEQ {
         ch_versions = ch_versions.mix(CLASSIFY_UNMAPPED.out.versions)
     } else {
         // executes SORTBAM on aligned trimmed reads
-        / executes SORTBAM on input files from CSV
+        // executes SORTBAM on input files from CSV
         SORTBAM (
             PREPARE_READS.out.bam
         )


### PR DESCRIPTION
## Motivation

This PR introduces the following improvements:

- the branch of the pipeline originally accepting BAM inputs is now able to accept also CRAM input files
- the bam/cram sort and index processes were repeated under 2 different subworkflows: they have been removed and a new dedicated subworkflow has been added, and new channels reconnected to the other ones. this optimises computation
- a failsafe for file names has been added to the RMarkdown script
- a couple of small improvements have been introduced in the documentation, to make the pipeline usage clearer

This improved version has been tested on a full scale dataset of 90 Human exomes, besides *test* and *test_bam* profiles.

## PR checklist

- [ ] Tests have been run including full scale testing on real dataset (see above)
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)
- [ ]The code lints (`nf-core lint`): modules updates will be handled in a new PR
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
