### PR TITLE
fix sorted bam names

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Note that some form of configuration will be needed so that Nextflow knows how t
    nextflow run nf-core/hgtseq \
    --input <YOURINPUT>.csv \
    --outdir <OUTDIR> \
-   --genome GRCh38 \
+   --genome GATK.GRCh38 \
    -profile <docker/singularity/podman/shifter/charliecloud/conda/institute> \
    --krakendb /path/to/kraken_db \
    --kronadb /path/to/krona_db/taxonomy.tab

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -11,117 +11,43 @@
 params {
     // illumina iGenomes reference file paths
     genomes {
-        'GATK.GRCh37' {
-            ascat_alleles         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/G1000_alleles_hg19.zip"
-            ascat_genome          = 'hg19'
-            ascat_loci            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/G1000_loci_hg19.zip"
-            ascat_loci_gc         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/GC_G1000_hg19.zip"
-            ascat_loci_rt         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/RT_G1000_hg19.zip"
-            bwa                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/BWAIndex/"
-            chr_dir               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/Chromosomes"
-            dbsnp                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/dbsnp_138.b37.vcf.gz"
-            dbsnp_tbi             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/dbsnp_138.b37.vcf.gz.tbi"
-            dbsnp_vqsr            = '--resource:dbsnp,known=false,training=true,truth=false,prior=2.0 dbsnp_138.b37.vcf.gz'
-            dict                  = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.dict"
-            fasta                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.fasta"
-            fasta_fai             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.fasta.fai"
-            germline_resource     = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/af-only-gnomad.raw.sites.vcf.gz"
-            germline_resource_tbi = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/af-only-gnomad.raw.sites.vcf.gz.tbi"
-            intervals             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/intervals/wgs_calling_regions_Sarek.list"
-            known_snps            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/1000G_phase1.snps.high_confidence.b37.vcf.gz"
-            known_snps_tbi        = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi"
-            known_snps_vqsr       = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_phase1.snps.high_confidence.b37.vcf.gz'
-            known_indels          = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf.gz"
-            known_indels_tbi      = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf.gz.tbi"
-            known_indels_vqsr     = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_phase1.indels.b37.vcf.gz --resource:mills,known=false,training=true,truth=true,prior=10.0 Mills_and_1000G_gold_standard.indels.b37.vcf.gz'
-            mappability           = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/Control-FREEC/out100m2_hg19.gem"
-            snpeff_db             = 'GRCh37.87'
-            snpeff_genome         = 'GRCh37'
-            snpeff_version        = '5.1'
-            vep_cache_version     = 106
-            vep_genome            = 'GRCh37'
-            vep_species           = 'homo_sapiens'
-            vep_version           = '106.1'
+        'GRCh37' {
+            fasta       = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa"
+            bwa         = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/version0.6.0/"
+            bowtie2     = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/Bowtie2Index/"
+            star        = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/STARIndex/"
+            bismark     = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BismarkIndex/"
+            gtf         = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/Genes/genes.gtf"
+            bed12       = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/Genes/genes.bed"
+            readme      = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/README.txt"
+            mito_name   = "MT"
+            macs_gsize  = "2.7e9"
+            blacklist   = "${projectDir}/assets/blacklists/GRCh37-blacklist.bed"
         }
-        'GATK.GRCh38' {
-            ascat_alleles         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/G1000_alleles_hg38.zip"
-            ascat_genome          = 'hg38'
-            ascat_loci            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/G1000_loci_hg38.zip"
-            ascat_loci_gc         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/GC_G1000_hg38.zip"
-            ascat_loci_rt         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/RT_G1000_hg38.zip"
-            bwa                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/BWAIndex/"
-            bwamem2               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/BWAmem2Index/"
-            dragmap               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/dragmap/"
-            chr_dir               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/Chromosomes"
-            dbsnp                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/dbsnp_146.hg38.vcf.gz"
-            dbsnp_tbi             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/dbsnp_146.hg38.vcf.gz.tbi"
-            dbsnp_vqsr            = '--resource:dbsnp,known=false,training=true,truth=false,prior=2.0 dbsnp_146.hg38.vcf.gz'
-            dict                  = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.dict"
-            fasta                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.fasta"
-            fasta_fai             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.fasta.fai"
-            germline_resource     = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/af-only-gnomad.hg38.vcf.gz"
-            germline_resource_tbi = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/af-only-gnomad.hg38.vcf.gz.tbi"
-            intervals             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/intervals/wgs_calling_regions.hg38.bed"
-            known_snps            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000G_omni2.5.hg38.vcf.gz"
-            known_snps_tbi        = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000G_omni2.5.hg38.vcf.gz.tbi"
-            known_snps_vqsr       = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_omni2.5.hg38.vcf.gz'
-            known_indels          = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz"
-            known_indels_tbi      = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz.tbi"
-            known_indels_vqsr     = '--resource:gatk,known=false,training=true,truth=true,prior=10.0 Homo_sapiens_assembly38.known_indels.vcf.gz --resource:mills,known=false,training=true,truth=true,prior=10.0 Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
-            mappability           = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/Control-FREEC/out100m2_hg38.gem"
-            pon                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz"
-            pon_tbi               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz.tbi"
-            snpeff_db             = 'GRCh38.105'
-            snpeff_genome         = 'GRCh38'
-            snpeff_version        = '5.1'
-            vep_cache_version     = 106
-            vep_genome            = 'GRCh38'
-            vep_species           = 'homo_sapiens'
-            vep_version           = '106.1'
-        }
-        'Ensembl.GRCh37' {
-            bwa                   = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/version0.6.0/"
-            fasta                 = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa"
-            readme                = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/README.txt"
-            snpeff_db             = 'GRCh37.87'
-            snpeff_genome         = 'GRCh37'
-            snpeff_version        = '5.1'
-            vep_cache_version     = 106
-            vep_genome            = 'GRCh37'
-            vep_species           = 'homo_sapiens'
-            vep_version           = '106.1'
-        }
-        'NCBI.GRCh38' {
-            bwa                   = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BWAIndex/version0.6.0/"
-            fasta                 = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
-            snpeff_db             = 'GRCh38.105'
-            snpeff_genome         = 'GRCh38'
-            snpeff_version        = '5.1'
-            vep_cache_version     = 106
-            vep_genome            = 'GRCh38'
-            vep_species           = 'homo_sapiens'
-            vep_version           = '106.1'
+        'GRCh38' {
+            fasta       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
+            bwa         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BWAIndex/version0.6.0/"
+            bowtie2     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/Bowtie2Index/"
+            star        = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/"
+            bismark     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BismarkIndex/"
+            gtf         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf"
+            bed12       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed"
+            mito_name   = "chrM"
+            macs_gsize  = "2.7e9"
+            blacklist   = "${projectDir}/assets/blacklists/hg38-blacklist.bed"
         }
         'GRCm38' {
-            bwa                   = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BWAIndex/version0.6.0/"
-            chr_dir               = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/Chromosomes"
-            dbsnp                 = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.snps_all.dbSNP142.vcf.gz"
-            dbsnp_tbi             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.snps_all.dbSNP142.vcf.gz.tbi"
-            dict                  = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.dict"
-            fasta                 = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa"
-            fasta_fai             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa.fai"
-            intervals             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/intervals/GRCm38_calling_list.bed"
-            known_indels          = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.indels.dbSNP142.normed.vcf.gz"
-            known_indels_tbi      = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.indels.dbSNP142.normed.vcf.gz.tbi"
-            mappability           = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Control-FREEC/GRCm38_68_mm10.gem"
-            readme                = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/README.txt"
-            snpeff_db             = 'GRCm38.99'
-            snpeff_genome         = 'GRCm38'
-            snpeff_version        = '5.1'
-            vep_cache_version     = 102
-            vep_genome            = 'GRCm38'
-            vep_species           = 'mus_musculus'
-            vep_version           = '106.1'
+            fasta       = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa"
+            bwa         = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BWAIndex/version0.6.0/"
+            bowtie2     = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/Bowtie2Index/"
+            star        = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/STARIndex/"
+            bismark     = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BismarkIndex/"
+            gtf         = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Genes/genes.gtf"
+            bed12       = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Genes/genes.bed"
+            readme      = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/README.txt"
+            mito_name   = "MT"
+            macs_gsize  = "1.87e9"
+            blacklist   = "${projectDir}/assets/blacklists/GRCm38-blacklist.bed"
         }
         'TAIR10' {
             fasta       = "${params.igenomes_base}/Arabidopsis_thaliana/Ensembl/TAIR10/Sequence/WholeGenomeFasta/genome.fa"

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -11,43 +11,117 @@
 params {
     // illumina iGenomes reference file paths
     genomes {
-        'GRCh37' {
-            fasta       = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa"
-            bwa         = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/version0.6.0/"
-            bowtie2     = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/Bowtie2Index/"
-            star        = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/STARIndex/"
-            bismark     = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BismarkIndex/"
-            gtf         = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/Genes/genes.gtf"
-            bed12       = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/Genes/genes.bed"
-            readme      = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/README.txt"
-            mito_name   = "MT"
-            macs_gsize  = "2.7e9"
-            blacklist   = "${projectDir}/assets/blacklists/GRCh37-blacklist.bed"
+        'GATK.GRCh37' {
+            ascat_alleles         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/G1000_alleles_hg19.zip"
+            ascat_genome          = 'hg19'
+            ascat_loci            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/G1000_loci_hg19.zip"
+            ascat_loci_gc         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/GC_G1000_hg19.zip"
+            ascat_loci_rt         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/ASCAT/RT_G1000_hg19.zip"
+            bwa                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/BWAIndex/"
+            chr_dir               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/Chromosomes"
+            dbsnp                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/dbsnp_138.b37.vcf.gz"
+            dbsnp_tbi             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/dbsnp_138.b37.vcf.gz.tbi"
+            dbsnp_vqsr            = '--resource:dbsnp,known=false,training=true,truth=false,prior=2.0 dbsnp_138.b37.vcf.gz'
+            dict                  = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.dict"
+            fasta                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.fasta"
+            fasta_fai             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Sequence/WholeGenomeFasta/human_g1k_v37_decoy.fasta.fai"
+            germline_resource     = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/af-only-gnomad.raw.sites.vcf.gz"
+            germline_resource_tbi = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/af-only-gnomad.raw.sites.vcf.gz.tbi"
+            intervals             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/intervals/wgs_calling_regions_Sarek.list"
+            known_snps            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/1000G_phase1.snps.high_confidence.b37.vcf.gz"
+            known_snps_tbi        = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/1000G_phase1.snps.high_confidence.b37.vcf.gz.tbi"
+            known_snps_vqsr       = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_phase1.snps.high_confidence.b37.vcf.gz'
+            known_indels          = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf.gz"
+            known_indels_tbi      = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/GATKBundle/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf.gz.tbi"
+            known_indels_vqsr     = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_phase1.indels.b37.vcf.gz --resource:mills,known=false,training=true,truth=true,prior=10.0 Mills_and_1000G_gold_standard.indels.b37.vcf.gz'
+            mappability           = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh37/Annotation/Control-FREEC/out100m2_hg19.gem"
+            snpeff_db             = 'GRCh37.87'
+            snpeff_genome         = 'GRCh37'
+            snpeff_version        = '5.1'
+            vep_cache_version     = 106
+            vep_genome            = 'GRCh37'
+            vep_species           = 'homo_sapiens'
+            vep_version           = '106.1'
         }
-        'GRCh38' {
-            fasta       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
-            bwa         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BWAIndex/version0.6.0/"
-            bowtie2     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/Bowtie2Index/"
-            star        = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/"
-            bismark     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BismarkIndex/"
-            gtf         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf"
-            bed12       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed"
-            mito_name   = "chrM"
-            macs_gsize  = "2.7e9"
-            blacklist   = "${projectDir}/assets/blacklists/hg38-blacklist.bed"
+        'GATK.GRCh38' {
+            ascat_alleles         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/G1000_alleles_hg38.zip"
+            ascat_genome          = 'hg38'
+            ascat_loci            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/G1000_loci_hg38.zip"
+            ascat_loci_gc         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/GC_G1000_hg38.zip"
+            ascat_loci_rt         = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/ASCAT/RT_G1000_hg38.zip"
+            bwa                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/BWAIndex/"
+            bwamem2               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/BWAmem2Index/"
+            dragmap               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/dragmap/"
+            chr_dir               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/Chromosomes"
+            dbsnp                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/dbsnp_146.hg38.vcf.gz"
+            dbsnp_tbi             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/dbsnp_146.hg38.vcf.gz.tbi"
+            dbsnp_vqsr            = '--resource:dbsnp,known=false,training=true,truth=false,prior=2.0 dbsnp_146.hg38.vcf.gz'
+            dict                  = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.dict"
+            fasta                 = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.fasta"
+            fasta_fai             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Sequence/WholeGenomeFasta/Homo_sapiens_assembly38.fasta.fai"
+            germline_resource     = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/af-only-gnomad.hg38.vcf.gz"
+            germline_resource_tbi = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/af-only-gnomad.hg38.vcf.gz.tbi"
+            intervals             = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/intervals/wgs_calling_regions.hg38.bed"
+            known_snps            = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000G_omni2.5.hg38.vcf.gz"
+            known_snps_tbi        = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000G_omni2.5.hg38.vcf.gz.tbi"
+            known_snps_vqsr       = '--resource:1000G,known=false,training=true,truth=true,prior=10.0 1000G_omni2.5.hg38.vcf.gz'
+            known_indels          = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz"
+            known_indels_tbi      = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz.tbi"
+            known_indels_vqsr     = '--resource:gatk,known=false,training=true,truth=true,prior=10.0 Homo_sapiens_assembly38.known_indels.vcf.gz --resource:mills,known=false,training=true,truth=true,prior=10.0 Mills_and_1000G_gold_standard.indels.hg38.vcf.gz'
+            mappability           = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/Control-FREEC/out100m2_hg38.gem"
+            pon                   = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz"
+            pon_tbi               = "${params.igenomes_base}/Homo_sapiens/GATK/GRCh38/Annotation/GATKBundle/1000g_pon.hg38.vcf.gz.tbi"
+            snpeff_db             = 'GRCh38.105'
+            snpeff_genome         = 'GRCh38'
+            snpeff_version        = '5.1'
+            vep_cache_version     = 106
+            vep_genome            = 'GRCh38'
+            vep_species           = 'homo_sapiens'
+            vep_version           = '106.1'
+        }
+        'Ensembl.GRCh37' {
+            bwa                   = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/BWAIndex/version0.6.0/"
+            fasta                 = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Sequence/WholeGenomeFasta/genome.fa"
+            readme                = "${params.igenomes_base}/Homo_sapiens/Ensembl/GRCh37/Annotation/README.txt"
+            snpeff_db             = 'GRCh37.87'
+            snpeff_genome         = 'GRCh37'
+            snpeff_version        = '5.1'
+            vep_cache_version     = 106
+            vep_genome            = 'GRCh37'
+            vep_species           = 'homo_sapiens'
+            vep_version           = '106.1'
+        }
+        'NCBI.GRCh38' {
+            bwa                   = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BWAIndex/version0.6.0/"
+            fasta                 = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/WholeGenomeFasta/genome.fa"
+            snpeff_db             = 'GRCh38.105'
+            snpeff_genome         = 'GRCh38'
+            snpeff_version        = '5.1'
+            vep_cache_version     = 106
+            vep_genome            = 'GRCh38'
+            vep_species           = 'homo_sapiens'
+            vep_version           = '106.1'
         }
         'GRCm38' {
-            fasta       = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa"
-            bwa         = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BWAIndex/version0.6.0/"
-            bowtie2     = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/Bowtie2Index/"
-            star        = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/STARIndex/"
-            bismark     = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BismarkIndex/"
-            gtf         = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Genes/genes.gtf"
-            bed12       = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Genes/genes.bed"
-            readme      = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/README.txt"
-            mito_name   = "MT"
-            macs_gsize  = "1.87e9"
-            blacklist   = "${projectDir}/assets/blacklists/GRCm38-blacklist.bed"
+            bwa                   = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/BWAIndex/version0.6.0/"
+            chr_dir               = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/Chromosomes"
+            dbsnp                 = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.snps_all.dbSNP142.vcf.gz"
+            dbsnp_tbi             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.snps_all.dbSNP142.vcf.gz.tbi"
+            dict                  = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.dict"
+            fasta                 = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa"
+            fasta_fai             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Sequence/WholeGenomeFasta/genome.fa.fai"
+            intervals             = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/intervals/GRCm38_calling_list.bed"
+            known_indels          = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.indels.dbSNP142.normed.vcf.gz"
+            known_indels_tbi      = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/MouseGenomeProject/mgp.v5.merged.indels.dbSNP142.normed.vcf.gz.tbi"
+            mappability           = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/Control-FREEC/GRCm38_68_mm10.gem"
+            readme                = "${params.igenomes_base}/Mus_musculus/Ensembl/GRCm38/Annotation/README.txt"
+            snpeff_db             = 'GRCm38.99'
+            snpeff_genome         = 'GRCm38'
+            snpeff_version        = '5.1'
+            vep_cache_version     = 102
+            vep_genome            = 'GRCm38'
+            vep_species           = 'mus_musculus'
+            vep_version           = '106.1'
         }
         'TAIR10' {
             fasta       = "${params.igenomes_base}/Arabidopsis_thaliana/Ensembl/TAIR10/Sequence/WholeGenomeFasta/genome.fa"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -178,6 +178,9 @@ process {
     }
 
     withName: QUALIMAP_BAMQC {
+        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 32.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
         publishDir = [
             path: { "${params.outdir}/QC/qualimap" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -42,6 +42,14 @@ process {
         ]
     }
 
+    withName: 'BWAMEM1_INDEX' {
+        ext.when = { !params.bwaindex && params.aligner == "bwa-mem" }
+    }
+
+    withName: 'BWAMEM2_INDEX' {
+        ext.when = { !params.bwamem2index && params.aligner == "bwa-mem2" }
+    }
+
     withName: BWAMEM1_MEM {
         publishDir = [
             path: { "${params.outdir}/preprocess/alignment" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -84,7 +84,14 @@ process {
             path: { "${params.outdir}/preprocess/alignment" },
             mode: params.publish_dir_mode
         ]
-        ext.prefix = "sorted"
+        ext.prefix = { "${meta.id}_sorted" }
+    }
+
+    withName: SAMTOOLS_INDEX {
+        publishDir = [
+            path: { "${params.outdir}/preprocess/alignment" },
+            mode: params.publish_dir_mode
+        ]
     }
 
     withName: SAMTOOLS_VIEW_SINGLE {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -178,9 +178,9 @@ process {
     }
 
     withName: QUALIMAP_BAMQC {
-        cpus   = { check_max( 6     * task.attempt, 'cpus'    ) }
-        memory = { check_max( 32.GB * task.attempt, 'memory'  ) }
-        time   = { check_max( 8.h   * task.attempt, 'time'    ) }
+        cpus   = { check_max( 8     * task.attempt, 'cpus'    ) }
+        memory = { check_max( 64.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 24.h   * task.attempt, 'time'    ) }
         publishDir = [
             path: { "${params.outdir}/QC/qualimap" },
             mode: params.publish_dir_mode,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,7 +55,7 @@ The typical command for running the pipeline is as follows:
 nextflow run nf-core/hgtseq \
 --input samplesheet.csv \
 --outdir <OUTDIR> \
---genome GRCh38 \
+--genome GATK.GRCh38 \
 -profile <singularity,docker,conda> \
 --krakendb /path/to/kraken_db \
 --kronadb /path/to/krona_db/taxonomy.tab
@@ -258,7 +258,7 @@ NXF_OPTS='-Xms1g -Xmx4g'
 
 ## Limitations
 
-- `Reporting Subworkflow` only works with human data (i.e. setting _is_human = true_ and GRCh38 genome required)
+- `Reporting Subworkflow` only works with human data (i.e. setting _is_human = true_ and GATK.GRCh38 or NCBI.GRCh38 genome required)
 - If using `conda` as profile, hgtseq pipeline runs without executing `Reporting Subworkflow` due to a conflict between ggbio and RMarkDown
 - Since small databases should be used to run the tests, their results might be compromised or inconsistent (i.e. SARS-CoV-2 [Krakendb](https://github.com/nf-core/test-datasets/tree/modules/data/genomics/sarscov2/genome/db) and [Kronadb](https://github.com/nf-core/test-datasets/blob/modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab) for human data).
   For tis reason, we recommend testing pipeline with your own valid database.

--- a/main.nf
+++ b/main.nf
@@ -17,8 +17,10 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-params.fasta = WorkflowMain.getGenomeAttribute(params, 'fasta')
-params.gff   = WorkflowMain.getGenomeAttribute(params, 'gtf')
+params.fasta        = WorkflowMain.getGenomeAttribute(params, 'fasta')
+params.gff          = WorkflowMain.getGenomeAttribute(params, 'gtf')
+params.bwaindex     = WorkflowMain.getGenomeAttribute(params, 'bwa')
+params.bwamem2index = WorkflowMain.getGenomeAttribute(params, 'bwamem2')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -146,10 +143,7 @@
                     "hidden": true
                 }
             },
-            "required": [
-                "krakendb",
-                "kronadb"
-            ]
+            "required": ["krakendb", "kronadb"]
         },
         "institutional_config_options": {
             "title": "Institutional config options",
@@ -253,14 +247,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -129,9 +132,23 @@
                     "description": "Path to GFF/GTF annotation file.",
                     "help_text": "This parameter is *mandatory* if `--genome` is not specified.",
                     "hidden": true
+                },
+                "bwaindex": {
+                    "type": "string",
+                    "default": null,
+                    "hidden": true
+                },
+                "bwamem2index": {
+                    "type": "string",
+                    "default": null,
+                    "hidden": true
                 }
             },
-            "required": ["is_human", "krakendb", "kronadb"]
+            "required": [
+                "is_human",
+                "krakendb",
+                "kronadb"
+            ]
         },
         "institutional_config_options": {
             "title": "Institutional config options",
@@ -235,7 +252,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -136,11 +136,13 @@
                 "bwaindex": {
                     "type": "string",
                     "default": null,
+                    "description": "Path bwa-mem indexes",
                     "hidden": true
                 },
                 "bwamem2index": {
                     "type": "string",
                     "default": null,
+                    "description": "Path bwa-mem2 indexes",
                     "hidden": true
                 }
             },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -147,7 +147,6 @@
                 }
             },
             "required": [
-                "is_human",
                 "krakendb",
                 "kronadb"
             ]

--- a/subworkflows/local/prepare_reads/main.nf
+++ b/subworkflows/local/prepare_reads/main.nf
@@ -29,21 +29,27 @@ workflow PREPARE_READS {
     ch_versions = ch_versions.mix(TRIMGALORE.out.versions)
 
     if (aligner == "bwa-mem") {
-        // reference is indexed
+        // reference is indexed if index not available in iGenomes
         BWAMEM1_INDEX ( fasta )
         ch_versions = ch_versions.mix(BWAMEM1_INDEX.out.versions)
 
+        // sets bwaindex to correct input
+        bwaindex      = params.fasta ? params.bwaindex      ? Channel.fromPath(params.bwaindex).collect()      : BWAMEM1_INDEX.out.index : []
+
         // appropriately tagged interleaved FASTQ reads are mapped to the reference
-        BWAMEM1_MEM ( TRIMGALORE.out.reads, BWAMEM1_INDEX.out.index, false )
+        BWAMEM1_MEM ( TRIMGALORE.out.reads, bwaindex, false )
         ch_versions = ch_versions.mix(BWAMEM1_MEM.out.versions)
         aligned_bam = BWAMEM1_MEM.out.bam
     } else {
-        // reference is indexed
+        // reference is indexed if index not available in iGenomes
         BWAMEM2_INDEX ( fasta )
         ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
 
+        // sets bwamem2index to correct input
+        bwamem2index  = params.fasta ? params.bwamem2index  ? Channel.fromPath(params.bwamem2index).collect()  : BWAMEM2_INDEX.out.index : []
+
         // appropriately tagged interleaved FASTQ reads are mapped to the reference
-        BWAMEM2_MEM ( TRIMGALORE.out.reads, BWAMEM2_INDEX.out.index, false )
+        BWAMEM2_MEM ( TRIMGALORE.out.reads, bwamem2index, false )
         ch_versions = ch_versions.mix(BWAMEM2_MEM.out.versions)
         aligned_bam = BWAMEM2_MEM.out.bam
     }


### PR DESCRIPTION
This PR closes issue #9 
modules config was configured with static `ext.prefix`
correct syntax to catch dynamic `meta.id` naming is introduced.
no additional problems where identified: all other channels were correct and names reformatted in downstream modules, which is why this problem only appeared in samtools stats, which was an endpoint.

Please note that this fix is made branching off Pull Request #8: this will result in the same commits being submitted here, and therefore PR duplicated.
