### PR TITLE
Small changes to Documention

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -34,5 +34,5 @@ params {
     kronadb  = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
 
     // reporting only if Human data
-    taxonomy_id = "9541"
+    taxonomy_id = "9606"
 }

--- a/conf/test_bam.config
+++ b/conf/test_bam.config
@@ -34,5 +34,5 @@ params {
     kronadb  = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
 
     // reporting only if Human data
-    taxonomy_id = "9541"
+    taxonomy_id = "9606"
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -36,6 +36,6 @@ params {
     kronadb  = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
 
     // reporting only if Human data
-    is_human = true
+    taxonomy_id = "9606"
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,6 +56,7 @@ nextflow run nf-core/hgtseq \
 --input samplesheet.csv \
 --outdir <OUTDIR> \
 --genome GATK.GRCh38 \
+--taxonomy_id "TAXID"
 -profile <singularity,docker,conda> \
 --krakendb /path/to/kraken_db \
 --kronadb /path/to/krona_db/taxonomy.tab


### PR DESCRIPTION
Forgot to update the _usage.md_ file specifying to add the param `--taxonomy_id` in the command line when you want to run the pipeline.

Also changed taxID in the tests config.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/hgtseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
