### PR TITLE
Removed "seqinfo(hg19sub)" in markdown report

### DIFF
--- a/assets/analysis_report.Rmd
+++ b/assets/analysis_report.Rmd
@@ -99,8 +99,6 @@ data_classified_both = data_classified_both %>%
 ```{r seqInfo, include=FALSE, eval=eval_taxid}
 
 data("CRC", package = "biovizBase")
-head(hg19sub)
-seqinfo(hg19sub)
 
 dictionary = "https://raw.githubusercontent.com/nf-core/test-datasets/hgtseq/testdata/reference/Homo_sapiens_assembly38.dict"
 dictred = read_tsv(dictionary, skip = 1, col_names = c("class", "sequence", "length", "m5", "as", "url", "species"))


### PR DESCRIPTION
Fixed `analysis_report.Rmd` as suggested by @FriederikeHanssen in PR review.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/hgtseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
