### PR TITLE
Added local module to correct samtools view command

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -100,6 +100,7 @@ process {
             mode: params.publish_dir_mode
         ]
         ext.args = '-b -f 5 -F 256'
+        ext.args2 = '-b -F 8'
     }
 
     withName: SAMTOOLS_VIEW_BOTH {

--- a/modules/local/samtools/viewsingle/main.nf
+++ b/modules/local/samtools/viewsingle/main.nf
@@ -1,0 +1,69 @@
+process SAMTOOLS_VIEW_SINGLE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::samtools=1.15.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.15.1--h1170115_0' :
+        'quay.io/biocontainers/samtools:1.15.1--h1170115_0' }"
+
+    input:
+    tuple val(meta), path(input), path(index)
+    path fasta
+    path qname
+
+    output:
+    tuple val(meta), path("*.bam"),  emit: bam,     optional: true
+    tuple val(meta), path("*.cram"), emit: cram,    optional: true
+    tuple val(meta), path("*.sam"),  emit: sam,     optional: true
+    tuple val(meta), path("*.bai"),  emit: bai,     optional: true
+    tuple val(meta), path("*.csi"),  emit: csi,     optional: true
+    tuple val(meta), path("*.crai"), emit: crai,    optional: true
+    path  "versions.yml",            emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ""
+    def readnames = qname ? "--qname-file ${qname}": ""
+    def file_type = args.contains("--output-fmt sam") ? "sam" :
+                    args.contains("--output-fmt bam") ? "bam" :
+                    args.contains("--output-fmt cram") ? "cram" :
+                    input.getExtension()
+    if ("$input" == "${prefix}.${file_type}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    samtools \\
+        view \\
+        --threads ${task.cpus-1} \\
+        ${reference} \\
+        ${readnames} \\
+        $args \\
+        $input \\
+        | samtools view $args2 \\
+        --threads ${task.cpus-1} \\
+        ${reference} \\
+        ${readnames} \\
+        -o ${prefix}.${file_type}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bam
+    touch ${prefix}.cram
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/subworkflows/local/classify_unmapped/main.nf
+++ b/subworkflows/local/classify_unmapped/main.nf
@@ -1,7 +1,7 @@
 
 include { SAMTOOLS_INDEX                              } from '../../../modules/nf-core/samtools/index/main.nf'
 include { SAMTOOLS_SORT                               } from '../../../modules/nf-core/samtools/sort/main.nf'
-include { SAMTOOLS_VIEW   as SAMTOOLS_VIEW_SINGLE     } from '../../../modules/nf-core/samtools/view/main.nf'
+include { SAMTOOLS_VIEW_SINGLE                        } from '../../../modules/local/samtools/viewsingle/main.nf'
 include { SAMTOOLS_VIEW   as SAMTOOLS_VIEW_BOTH       } from '../../../modules/nf-core/samtools/view/main.nf'
 include { SAMTOOLS_FASTQ  as SAMTOOLS_FASTQ_SINGLE    } from '../../../modules/local/samtools/fastqlocal/main.nf'
 include { SAMTOOLS_FASTQ  as SAMTOOLS_FASTQ_BOTH      } from '../../../modules/local/samtools/fastqlocal/main.nf'


### PR DESCRIPTION
In this PR we added a local module "samtools/viewsingle" to combine two SAMtools command, in order to fix a bug when extracting reads by sam flag.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/hgtseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/hgtseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
