### PR TITLE
Fix syntax error in `test_full.config`

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,10 +16,6 @@ params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'
 
-params {
-    config_profile_name        = 'Test profile'
-    config_profile_description = 'Minimal test dataset to check pipeline function'
-
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2
     max_memory = '8.GB'


### PR DESCRIPTION
Removed duplicate opening `params {` statement
